### PR TITLE
Player / Bot player with the last hit

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11211,6 +11211,11 @@ bool Unit::InitTamedPet(Pet* pet, uint8 level, uint32 spell_id)
         {
             if (Player* killed = victim->ToPlayer())
                 sScriptMgr->OnPlayerKilledByCreature(killerCre, killed);
+            else if (Creature* killedCre = victim->ToCreature())
+            {
+                if (killerCre->IsNPCBotOrPet() && !killerCre->IsFreeBot())
+                    sScriptMgr->OnCreatureKill(killerCre->GetBotOwner(), killedCre);
+            }
         }
     }
 }


### PR DESCRIPTION
I would say OnCreatureKill() is not the best way to hook creature death, judging from the code in Unit.cpp:Unit::Kill() you can run into the same problem if player's pet or any other summoned creature deals the killing blow.

TrinityCore uses loot recipient and loot damage requirement to determine player / group to receive the reward for killing, there is only a small addition to that from bots which is to set loot recepient to master so, unlike with pet, player can loot the creature even if bots do all the damage.

For scripted creatures normally after kill actions are handled by using JustDied() hook is creature script, sometimes DamageTaken() if creature doesn't really die, or, in case it's a smart script, probably with SMART_EVENT_DEATH -> SMART_ACTION_SUMMON_GO (I rarely do anything with smart scripts).

Alternatively, if you are desperate for a quick fix, you can just force OnCreatureKill() hook using master as killer

https://github.com/trickerer/Trinity-Bots/issues/199

```
@@ -11586,6 +11586,11 @@ bool Unit::Kill(Unit*, Unit*, bool)
        {
            if (Player* killed = victim->ToPlayer())
                sScriptMgr->OnPlayerKilledByCreature(killerCre, killed);
+            else if (Creature* killedCre = victim->ToCreature())
+            {
+                if (killerCre->IsNPCBotOrPet() && !killerCre->IsFreeBot())
+                    sScriptMgr->OnCreatureKill(killerCre->GetBotOwner(), killedCre);
+            }
        }
    }
}

```